### PR TITLE
Add redirect

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,3 @@
 include: [".well-known"]
+plugins:
+  - jekyll-redirect-from

--- a/anatomy-bootcamp/index.html
+++ b/anatomy-bootcamp/index.html
@@ -1,3 +1,6 @@
+---
+redirect_to: "https://anatomy.teambootcamp.com"
+---
 <!DOCTYPE html>
 <html>
 


### PR DESCRIPTION
When we're ready to redirect /anatomy-bootcamp to anatomy.teambootcamp.com, we can merge this.